### PR TITLE
cmake fixes for spack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,71 @@
 cmake_minimum_required (VERSION 3.0)
-project(sz)
-set (sz_VERSION_MAJOR 1)
-set (sz_VERSION_MINOR 0)
-set (CMAKE_CXX_STANDARD 11)
-set (CMAKE_CXX_STANDARD_REQUIRED ON)
-set (CMAKE_CXX_FLAGS "-g -O2")
-set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
+project(sz_cpp VERSION 1.0.11)
 
-find_library (ZSTD_LIBS zstd HINTS "/Users/xin/utils/sz/lib")
-set (ZSTD_INCLUDES "/Users/xin/utils/sz/include")
-add_subdirectory (src)
-add_subdirectory (test)
+include(CTest)
+include(GNUInstallDirs)
 
+#correct was to set a default build type
+# https://blog.kitware.com/cmake-and-the-default-build-type/
+set(default_build_type "Release")
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "No build type was set. Setting build type to ${default_build_type}.")
+  set(CMAKE_BUILD_TYPE ${default_build_type} CACHE 
+    STRING "Choose the type to build" FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
+    "MinSizeRel" "RelWithDebInfo")
+endif()
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+option(BUILD_SHARED_LIBS "build libpressio as a shared library" ON)
+
+find_package(PkgConfig REQUIRED)
+pkg_search_module(ZSTD IMPORTED_TARGET GLOBAL libzstd)
+
+add_library (sz_cpp  
+	src/sz_compression_utils.cpp
+	src/sz_compress_cp_preserve_2d.cpp
+	src/sz_compress_cp_preserve_3d.cpp
+	src/sz_compress_3d.cpp
+	src/sz_compress_pwr.cpp
+	src/sz_decompression_utils.cpp
+	src/sz_decompress_cp_preserve_2d.cpp
+	src/sz_decompress_cp_preserve_3d.cpp
+	src/sz_decompress_3d.cpp
+	src/sz_decompress_pwr.cpp
+	src/sz_huffman.cpp
+	src/sz_lossless.cpp)
+target_compile_features(sz_cpp PUBLIC cxx_std_11)
+target_include_directories(sz_cpp PUBLIC 
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  )
+target_link_libraries(sz_cpp PRIVATE PkgConfig::ZSTD)
+
+file(GLOB header_files ${PROJECT_SOURCE_DIR}/include/*.hpp)
+install(FILES ${header_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/sz_cpp)
+install (TARGETS sz_cpp EXPORT SZCppTargets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(EXPORT SZCppTargets NAMESPACE SZCpp:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/SZCpp/)
+include(CMakePackageConfigHelpers)
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/SZCppConfig.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/SZCppConfig.cmake"
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/SZCpp
+)
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/SZCppConfigVersion.cmake"
+  VERSION "${PROJECT_VERSION}"
+  COMPATIBILITY AnyNewerVersion
+)
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/SZCppConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/SZCppConfigVersion.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/SZCpp
+)
+
+if(BUILD_TESTING)
+  add_subdirectory (test)
+endif()

--- a/SZCppConfig.cmake.in
+++ b/SZCppConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/SZCppTargets.cmake")
+
+check_required_components(SZCpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,9 +11,8 @@ add_library (sz_cpp SHARED
 	sz_decompress_pwr.cpp
 	sz_huffman.cpp
 	sz_lossless.cpp)
-target_include_directories(sz_cpp PRIVATE ${ZSTD_INCLUDES})
 target_include_directories(sz_cpp PRIVATE ${PROJECT_SOURCE_DIR}/include)
-target_link_libraries(sz_cpp ${ZSTD_LIBS})
+target_link_libraries(sz_cpp PRIVATE PkgConfig::ZSTD)
 file(GLOB header_files ${PROJECT_SOURCE_DIR}/include/*.hpp)
 
 install(FILES ${header_files} DESTINATION ${PROJECT_BINARY_DIR}/include)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,24 +1,14 @@
 add_executable (sz_test sz_compress_test.cpp)
-target_include_directories (sz_test PRIVATE ${ZSTD_INCLUDES})
-target_include_directories (sz_test PRIVATE ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries (sz_test sz_cpp)
 
 add_executable (sz_test_with_eb sz_compress_test_with_eb.cpp)
-target_include_directories (sz_test_with_eb PRIVATE ${ZSTD_INCLUDES})
-target_include_directories (sz_test_with_eb PRIVATE ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries (sz_test_with_eb sz_cpp)
 
 add_executable (sz_compress_cp_preserve_2d_test sz_compress_cp_preserve_2d_test.cpp)
-target_include_directories (sz_compress_cp_preserve_2d_test PRIVATE ${ZSTD_INCLUDES})
-target_include_directories (sz_compress_cp_preserve_2d_test PRIVATE ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries (sz_compress_cp_preserve_2d_test sz_cpp)
 
 add_executable (sz_compress_cp_preserve_3d_test sz_compress_cp_preserve_3d_test.cpp)
-target_include_directories (sz_compress_cp_preserve_3d_test PRIVATE ${ZSTD_INCLUDES})
-target_include_directories (sz_compress_cp_preserve_3d_test PRIVATE ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries (sz_compress_cp_preserve_3d_test sz_cpp)
 
 add_executable (sz_compress_cp_preserve_3d_unstructured_test sz_compress_cp_preserve_3d_unstructured_test.cpp)
-target_include_directories (sz_compress_cp_preserve_3d_unstructured_test PRIVATE ${ZSTD_INCLUDES})
-target_include_directories (sz_compress_cp_preserve_3d_unstructured_test PRIVATE ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries (sz_compress_cp_preserve_3d_unstructured_test sz_cpp)


### PR DESCRIPTION
Various cmake fixes need to package SZCpp to be able to build MGARDx with spack for LibPresiso Support.

FYI @ayzk 